### PR TITLE
Fixed Mining Laser Ore Cluster & Bedrock Coltan bug

### DIFF
--- a/src/main/java/com/hbm/blocks/generic/BlockBedrockOre.java
+++ b/src/main/java/com/hbm/blocks/generic/BlockBedrockOre.java
@@ -24,13 +24,13 @@ public class BlockBedrockOre extends Block implements IDrillInteraction {
 
 	@Override
 	public boolean canBreak(World world, int x, int y, int z, IBlockState state, IMiningDrill drill) {
-		return drill.getDrillRating() > 70;
+		return false;
 	}
 
 	@Override
 	public ItemStack extractResource(World world, int x, int y, int z, IBlockState state, IMiningDrill drill) {
 		
-		if(drill.getDrillRating() > 70)
+		if (drill.getDrillRating() < 70)
 			return null;
 		
 		Item drop = this.getDrop();

--- a/src/main/java/com/hbm/blocks/generic/BlockCluster.java
+++ b/src/main/java/com/hbm/blocks/generic/BlockCluster.java
@@ -75,12 +75,12 @@ public class BlockCluster extends Block implements IDrillInteraction {
 
 	@Override
 	public boolean canBreak(World world, int x, int y, int z, IBlockState state, IMiningDrill drill) {
-		return drill.getDrillRating() <= 70 && world.rand.nextFloat() < 0.05;
+		return world.rand.nextFloat() < 0.05;
 	}
 
 	@Override
 	public ItemStack extractResource(World world, int x, int y, int z, IBlockState state, IMiningDrill drill) {
-		return drill.getDrillRating() <= 70 ? new ItemStack(getDrop()) : null;
+		return new ItemStack(getDrop());
 	}
 
 	@Override

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineMiningLaser.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineMiningLaser.java
@@ -390,6 +390,8 @@ public class TileEntityMachineMiningLaser extends TileEntityMachineBase implemen
 	public double getBreakSpeed(int speed) {
 
 		float hardness = world.getBlockState(new BlockPos(targetX, targetY, targetZ)).getBlockHardness(world, new BlockPos(targetX, targetY, targetZ)) * 15 / speed;
+		if (world.getBlockState(new BlockPos(targetX, targetY, targetZ)).getBlock() == ModBlocks.ore_bedrock_coltan)
+			hardness = 50;
 		if(hardness == 0)
 			return 1;
 
@@ -424,7 +426,7 @@ public class TileEntityMachineMiningLaser extends TileEntityMachineBase implemen
 	}
 
 	private boolean canBreak(IBlockState block, int x, int y, int z) {
-		return block.getBlock() != Blocks.AIR && block.getBlockHardness(world, new BlockPos(x, y, z)) >= 0 && !block.getMaterial().isLiquid() && block.getBlock() != Blocks.BEDROCK;
+		return block.getBlock() != Blocks.AIR && (block.getBlockHardness(world, new BlockPos(x, y, z)) >= 0 || block.getBlock() == ModBlocks.ore_bedrock_coltan) && !block.getMaterial().isLiquid() && block.getBlock() != Blocks.BEDROCK;
 	}
 
 	public int getOverdrive() {


### PR DESCRIPTION
1) Mining Laser has the same behavior as Mining Drill (5% to be destoyed).
2) Bedrock Coltan Ore can be extracted with Mining Laser (not Drill) as it was designed by default (2% to be extracted). Bedrock Coltan Ore cannot be destroyed by laser/drill (according to mexikoedi).